### PR TITLE
계정 생성 이후 서비스 이용에 필요한 필수 값 countycode, createdtime 추가

### DIFF
--- a/lib/admin/data/data_source/admin_data_source.dart
+++ b/lib/admin/data/data_source/admin_data_source.dart
@@ -3,13 +3,13 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 class AdminDataSource {
 
-  Future<void> postAcademyInfo(Map<String, String> data) async {
-    final String _uid = FirebaseAuth.instance.currentUser!.uid;
-    return await FirebaseFirestore.instance.collection('Academies').doc(_uid).set(data);
+  Future<void> postAcademyInfo(Map<String, dynamic> data) async {
+    final String uid = FirebaseAuth.instance.currentUser!.uid;
+    return await FirebaseFirestore.instance.collection('Academies').doc(uid).set(data);
   }
 
   Future<DocumentSnapshot<Map<String, dynamic>>> getAcademyInfo() async {
-    final String _uid = FirebaseAuth.instance.currentUser!.uid;
-    return await FirebaseFirestore.instance.collection('Academies').doc(_uid).get();
+    final String uid = FirebaseAuth.instance.currentUser!.uid;
+    return await FirebaseFirestore.instance.collection('Academies').doc(uid).get();
   }
 }

--- a/lib/admin/data/repository/admin_repository_impl.dart
+++ b/lib/admin/data/repository/admin_repository_impl.dart
@@ -14,8 +14,10 @@ class AdminRepositoryImpl implements AdminRepository {
   Future<void> postAcademyInfo(AcademyRequestDto academyRequestDto) async {
     final data = {
       'name': academyRequestDto.academyName,
-      'master': academyRequestDto.name,
-      'phone': academyRequestDto.number,
+      'master': academyRequestDto.masterName,
+      'phone': academyRequestDto.phoneNumber,
+      'countryCode': academyRequestDto.countryNumber,
+      'createdTime': academyRequestDto.createdTime,
     };
     await _adminDataSource.postAcademyInfo(data);
   }

--- a/lib/admin/presentation/academy_info_input_gate_screen.dart
+++ b/lib/admin/presentation/academy_info_input_gate_screen.dart
@@ -166,8 +166,9 @@ class _AcademyInfoInputGateScreenState
                       _validateNumber()) {
                     final academyRequestDto = AcademyRequestDto(
                       academyName: _formController1.text,
-                      name: _formController2.text,
-                      number: _formController3.text,
+                      masterName: _formController2.text,
+                      phoneNumber: _formController3.text,
+                      countryNumber: _dropdownValue.number,
                     );
                     await widget._viewModel.postAcademyInfo(academyRequestDto);
                     context.go('/studentList');

--- a/lib/admin/presentation/academy_info_input_gate_screen.dart
+++ b/lib/admin/presentation/academy_info_input_gate_screen.dart
@@ -3,14 +3,15 @@ import 'package:alimipro_mock_data/admin/presentation/view_model/academy_info_in
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-class AcademyInfoInputGateScreen extends StatefulWidget {
+import 'country.dart';
 
+class AcademyInfoInputGateScreen extends StatefulWidget {
   final AcademyInfoInputGateViewModel _viewModel;
 
   const AcademyInfoInputGateScreen({
     super.key,
     required AcademyInfoInputGateViewModel academyInfoInputGateViewModel,
-  })  : _viewModel = academyInfoInputGateViewModel;
+  }) : _viewModel = academyInfoInputGateViewModel;
 
   @override
   State<AcademyInfoInputGateScreen> createState() =>
@@ -22,6 +23,7 @@ class _AcademyInfoInputGateScreenState
   final _formController1 = TextEditingController();
   final _formController2 = TextEditingController();
   final _formController3 = TextEditingController();
+  Country _dropdownValue = Country.korea;
 
   @override
   void dispose() {
@@ -53,8 +55,8 @@ class _AcademyInfoInputGateScreenState
     return Scaffold(
       body: Center(
         child: SizedBox(
-          width: 400,
-          height: 400,
+          width: 500,
+          height: 500,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -66,6 +68,34 @@ class _AcademyInfoInputGateScreenState
                     'alimi.png',
                   ),
                 ),
+              ),
+              const SizedBox(
+                height: 32,
+              ),
+              Row(
+                children: [
+                  const Text(
+                    '국가',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                  const SizedBox(
+                    width: 16,
+                  ),
+                  DropdownButton<Country>(
+                    value: _dropdownValue,
+                    items: Country.values.map((e) {
+                      return DropdownMenuItem(
+                        value: e,
+                        child: Text(e.name),
+                      );
+                    }).toList(),
+                    onChanged: (Country? value) {
+                      setState(() {
+                        _dropdownValue = value!;
+                      });
+                    },
+                  ),
+                ],
               ),
               const SizedBox(
                 height: 16,

--- a/lib/admin/presentation/country.dart
+++ b/lib/admin/presentation/country.dart
@@ -1,0 +1,22 @@
+enum Country {
+
+  korea(name: 'Republic of Korea', number: '+82'),
+  america(name: 'USA', number: '+1'),
+  canada(name: 'Canada', number: '+1'),
+  russia(name: 'Russia', number: '+7'),
+  france(name: 'France', number: '+33'),
+  australia(name: 'Australia', number: '+61'),
+  philippines(name: 'Philippines', number: '+63'),
+  thailand(name: 'Thailand', number: '+66'),
+  japan(name: 'Japan', number: '+81'),
+  vietnam(name: 'Vietnam', number: '+84'),
+  china(name: 'China', number: '+86');
+
+  const Country({
+    required this.name,
+    required this.number,
+  });
+
+  final String name;
+  final String number;
+}

--- a/lib/admin/presentation/dto/academy_request_dto.dart
+++ b/lib/admin/presentation/dto/academy_request_dto.dart
@@ -1,12 +1,15 @@
 class AcademyRequestDto {
 
   final String academyName;
-  final String name;
-  final String number;
+  final String masterName;
+  final String phoneNumber;
+  final String countryNumber;
+  final DateTime createdTime = DateTime.now();
 
-  const AcademyRequestDto({
+  AcademyRequestDto({
     required this.academyName,
-    required this.name,
-    required this.number,
+    required this.masterName,
+    required this.phoneNumber,
+    required this.countryNumber,
   });
 }

--- a/lib/core/di/di_setup.config.dart
+++ b/lib/core/di/di_setup.config.dart
@@ -10,11 +10,11 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:alimipro_mock_data/core/di/app_module.dart' as _i21;
 import 'package:alimipro_mock_data/manage/data/data_source/academy_data_source.dart'
-    as _i5;
-import 'package:alimipro_mock_data/manage/data/data_source/log_data_source.dart'
-    as _i4;
-import 'package:alimipro_mock_data/manage/data/data_source/notice_data_source.dart'
     as _i6;
+import 'package:alimipro_mock_data/manage/data/data_source/log_data_source.dart'
+    as _i5;
+import 'package:alimipro_mock_data/manage/data/data_source/notice_data_source.dart'
+    as _i4;
 import 'package:alimipro_mock_data/manage/data/repository/academy_repository_impl.dart'
     as _i8;
 import 'package:alimipro_mock_data/manage/data/repository/log_data_repository_impl.dart'
@@ -30,13 +30,13 @@ import 'package:alimipro_mock_data/manage/domain/repository/notice_repository.da
 import 'package:alimipro_mock_data/manage/domain/use_case/get_academy_use_case.dart'
     as _i13;
 import 'package:alimipro_mock_data/manage/domain/use_case/get_notice_use_case.dart'
-    as _i15;
+    as _i16;
 import 'package:alimipro_mock_data/manage/domain/use_case/get_personal_punchlogs_use_case.dart'
     as _i17;
 import 'package:alimipro_mock_data/manage/domain/use_case/get_students_use_case.dart'
     as _i14;
 import 'package:alimipro_mock_data/manage/domain/use_case/set_students_use_case.dart'
-    as _i16;
+    as _i15;
 import 'package:alimipro_mock_data/manage/presentation/view_model/academy_student_list_view_model.dart'
     as _i19;
 import 'package:alimipro_mock_data/manage/presentation/view_model/notice_view_model.dart'
@@ -60,26 +60,26 @@ extension GetItInjectableX on _i1.GetIt {
     );
     final appModule = _$AppModule();
     gh.singleton<_i3.FirebaseFirestore>(() => appModule.firebaseFirestore);
-    gh.singleton<_i4.LogDataSource>(() =>
-        _i4.LogDataSource(firebaseFireStore: gh<_i3.FirebaseFirestore>()));
-    gh.singleton<_i5.AcademyDataSource>(() =>
-        _i5.AcademyDataSource(firebaseFireStore: gh<_i3.FirebaseFirestore>()));
-    gh.singleton<_i6.NoticeDataSource>(() =>
-        _i6.NoticeDataSource(firebaseFireStore: gh<_i3.FirebaseFirestore>()));
+    gh.singleton<_i4.NoticeDataSource>(() =>
+        _i4.NoticeDataSource(firebaseFireStore: gh<_i3.FirebaseFirestore>()));
+    gh.singleton<_i5.LogDataSource>(() =>
+        _i5.LogDataSource(firebaseFireStore: gh<_i3.FirebaseFirestore>()));
+    gh.singleton<_i6.AcademyDataSource>(() =>
+        _i6.AcademyDataSource(firebaseFireStore: gh<_i3.FirebaseFirestore>()));
     gh.singleton<_i7.AcademyRepository>(() => _i8.AcademyRepositoryImpl(
-        academyDataSource: gh<_i5.AcademyDataSource>()));
+        academyDataSource: gh<_i6.AcademyDataSource>()));
     gh.singleton<_i9.NoticeRepository>(() => _i10.NoticeRepositoryImpl(
-        noticeDataSource: gh<_i6.NoticeDataSource>()));
+        noticeDataSource: gh<_i4.NoticeDataSource>()));
     gh.singleton<_i11.LogDataRepository>(() =>
-        _i12.LogDataRepositoryImpl(logDataSource: gh<_i4.LogDataSource>()));
+        _i12.LogDataRepositoryImpl(logDataSource: gh<_i5.LogDataSource>()));
     gh.singleton<_i13.GetAcademyUseCase>(() =>
         _i13.GetAcademyUseCase(academyRepository: gh<_i7.AcademyRepository>()));
     gh.singleton<_i14.GetStudentsUseCase>(() => _i14.GetStudentsUseCase(
         academyRepository: gh<_i7.AcademyRepository>()));
-    gh.singleton<_i15.GetNoticeUseCase>(() =>
-        _i15.GetNoticeUseCase(noticeRepository: gh<_i9.NoticeRepository>()));
-    gh.singleton<_i16.SetNoticeUseCase>(() =>
-        _i16.SetNoticeUseCase(noticeRepository: gh<_i9.NoticeRepository>()));
+    gh.singleton<_i15.SetNoticeUseCase>(() =>
+        _i15.SetNoticeUseCase(noticeRepository: gh<_i9.NoticeRepository>()));
+    gh.singleton<_i16.GetNoticeUseCase>(() =>
+        _i16.GetNoticeUseCase(noticeRepository: gh<_i9.NoticeRepository>()));
     gh.singleton<_i17.GetPersonalPunchLogsUseCase>(() =>
         _i17.GetPersonalPunchLogsUseCase(
             logDataRepository: gh<_i11.LogDataRepository>()));
@@ -92,8 +92,8 @@ extension GetItInjectableX on _i1.GetIt {
               studentsUseCase: gh<_i14.GetStudentsUseCase>(),
             ));
     gh.factory<_i20.NoticeViewModel>(() => _i20.NoticeViewModel(
-          setNoticeUseCase: gh<_i16.SetNoticeUseCase>(),
-          noticeUseCase: gh<_i15.GetNoticeUseCase>(),
+          setNoticeUseCase: gh<_i15.SetNoticeUseCase>(),
+          noticeUseCase: gh<_i16.GetNoticeUseCase>(),
         ));
     return this;
   }

--- a/storage.rules
+++ b/storage.rules
@@ -6,7 +6,7 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {
-      allow read, write: if false;
+      allow read, write: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
### 작업 내용
- 일부 국가에 대한 국가 번호를 포함하는 enum 생성
  ```dart
  korea(name: 'Republic of Korea', number: '+82'),
  america(name: 'USA', number: '+1'),
  canada(name: 'Canada', number: '+1'),
  russia(name: 'Russia', number: '+7'),
  france(name: 'France', number: '+33'),
  australia(name: 'Australia', number: '+61'),
  philippines(name: 'Philippines', number: '+63'),
  thailand(name: 'Thailand', number: '+66'),
  japan(name: 'Japan', number: '+81'),
  vietnam(name: 'Vietnam', number: '+84'),
  china(name: 'China', number: '+86');
  ```
- 학원 정보 입력 화면에서 국가 선택을 위한 위젯 추가 (기본 값은 대한민국)
- 학원 정보 저장 시 국가 번호 및 생성 시각이 함께 저장되도록 변경